### PR TITLE
Removed pypy compatibility artifact

### DIFF
--- a/gksolite/render.py
+++ b/gksolite/render.py
@@ -1,5 +1,4 @@
 import sys
-import cpy2py
 import platform
 import atexit
 
@@ -77,51 +76,7 @@ class NativeMPLDisplay(object):
         pyplot.title(title)
         pyplot.imshow(content)
         pyplot.pause(0.000001)
-
-
-class CPyMPLDisplay(cpy2py.TwinObject):
-    """
-    Renderer for a Game of Life board or nested list for text terminals
-
-    :param height: the maximum height to display the board
-    :type height: int
-    :param width: the maximum width to display the board
-    :type width: int
-
-    This renderer requires :py:mod:`matplotlib` and :py:mod:`cpy2py`.
-    """
-    __twin_id__ = 'python3'
-
-    def __init__(self, height=640, width=640):
-        from matplotlib import pyplot
-        self.height = height
-        self.width = width
-        pyplot.draw()
-
-    @cpy2py.localmethod
-    def show(self, gol, title='<Title>'):
-        draw_height = min(self.height, gol.height)
-        draw_width = min(self.width, gol.width)
-        content = []
-        for line_idx in range(draw_height):
-            line = gol[line_idx]
-            content.append([line[row_idx] for row_idx in range(draw_width)])
-        self._show_mpl(content, title=title)
-
-    def _show_mpl(self, gol_array, title):
-        from matplotlib import pyplot
-        pyplot.clf()
-        pyplot.title(title)
-        pyplot.imshow(gol_array)
-        pyplot.pause(0.000001)
-
-if platform.python_implementation() == 'PyPy':
-    from cpy2py.ipyc import ipyc_socket
-    draw_twinterpreter = cpy2py.TwinMaster(CPyMPLDisplay.__twin_id__, ipyc=ipyc_socket.DuplexSocketIPyC)
-    draw_twinterpreter.start()
-    atexit.register(draw_twinterpreter.stop)
-    MPLDisplay = CPyMPLDisplay
-else:
-    MPLDisplay = NativeMPLDisplay
+        
+MPLDisplay = NativeMPLDisplay
 
 __all__ = ['TextDisplay', 'MPLDisplay', 'NullDisplay']


### PR DESCRIPTION
This change removes the ``cpy2py`` references required for compatibility with pypy. It is no longer in the dependencies of setup.py.